### PR TITLE
Validation array access warning

### DIFF
--- a/src/Plugin/YamlFormHandler/SalesforceObjectMappingHandler.php
+++ b/src/Plugin/YamlFormHandler/SalesforceObjectMappingHandler.php
@@ -137,7 +137,7 @@ class SalesforceObjectMappingHandler extends YamlFormHandlerBase {
    * @inheritdoc
    */
   public function validateConfigurationForm(array &$form, FormStateInterface $formState) {
-    if ($this->configuration['object']) {
+    if (isset($this->configuration['object'])) {
       // Ignore if we have already configured this object mapping.
       return;
     }


### PR DESCRIPTION
Fixed issue whereby accessing array key that doesn't exist on validation would throw a warning.